### PR TITLE
Route "exact" and "strict" params are not being respected when building routes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -11,8 +11,8 @@ const App = () => (
     <Switch>
       {routes.map(route =>
         <Route
-          exact
-          strict
+          exact={route.exact}
+          strict={route.strict}
           path={route.path}
           component={route.component}
           key={route.path}


### PR DESCRIPTION
```routes.js``` contain 4 params: path, component, exact and strict. However, application builds routes using only 2 of them. Submitted a small patch to fix this injustice :)