### PR TITLE
Add redux-devtools-extension to avoid errors in browsers without redux-devtools extension

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-redux": "^5.0.5",
     "react-router-dom": "^4.1.1",
     "redux": "^3.6.0",
+    "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,13 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
-import { createStore, combineReducers, applyMiddleware, compose } from 'redux';
+import { createStore, combineReducers, applyMiddleware } from 'redux';
 import { Provider } from 'react-redux';
 import thunkMiddleware from 'redux-thunk';
 import api from './reducers/api';
 import App from './App';
 // import registerServiceWorker from './registerServiceWorker';
+import { composeWithDevTools } from 'redux-devtools-extension/developmentOnly';
 
 const preloadedState = typeof window.__PRELOADED_STATE__ !== 'undefined' ? window.__PRELOADED_STATE__ : {};
 delete window.__PRELOADED_STATE__;
@@ -15,9 +16,8 @@ delete window.__PRELOADED_STATE__;
 const store = createStore(
   combineReducers({ api }),
   preloadedState,
-  compose(
-    applyMiddleware(thunkMiddleware),
-    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__(),
+  composeWithDevTools(
+    applyMiddleware(thunkMiddleware)
   ),
 );
 /* eslint-enable no-underscore-dangle */

--- a/yarn.lock
+++ b/yarn.lock
@@ -5076,6 +5076,10 @@ reduce-function-call@^1.0.1:
   dependencies:
     balanced-match "^0.4.2"
 
+redux-devtools-extension@^2.13.2:
+  version "2.13.2"
+  resolved "https://registry.yarnpkg.com/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz#e0f9a8e8dfca7c17be92c7124958a3b94eb2911d"
+
 redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"


### PR DESCRIPTION
If the client does not have the redux-devtools extension install, they'll probably encounter a "TypeError: Cannot read property 'apply' of undefined" as the `window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()` in src/index.js evaluates to false and is passed into the compose function.
